### PR TITLE
Support travis CI badge, ember observer info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember CLI Content for Index
+# Ember CLI Content for Index [![Build Status](https://travis-ci.org/CondeNast/ember-cli-content-for-index.svg?branch=master)](https://travis-ci.org/CondeNast/ember-cli-content-for-index)
 
 Automatically include HTML snippets in your Ember CLI index.html files.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-content-for-index",
   "version": "0.1.1",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "An Ember CLI addon to automatically include HTML snippets in your Ember CLI index.html files.",
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
## Why are we doing this?

This important field in the package.json was left unedited from the default content generated by Ember CLI

## Did you document your work?

Not required

## How can someone test these changes?

No


## What are the follow-up tasks?

Will need a release to take effect, but I will probably have other PRs for things like travis integration, etc. before a release is required.

